### PR TITLE
Use shelljs for npm scripts

### DIFF
--- a/.npm_scripts/postinstall.js
+++ b/.npm_scripts/postinstall.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const shelljs = require('shelljs');
+
+/**
+ * Working directory will be the "style-guide-typescript" module root
+ * The project directory is where the style rules should be set
+ */
+const PROJECT_DIR = path.resolve('../../');
+const TSLINT_PATH = path.resolve('tslint.json');
+const EDITORCONFIG_PATH = path.resolve('.editorconfig');
+
+/**
+ * Stop if npm install was run from the "style-guide-typescript" module.
+ * Continue only if this module is installed as a dependency.
+ */
+if ( __dirname.indexOf('node_modules') === -1 ) {
+    process.exit(0);
+}
+
+/**
+ * Copy tslint and editorconfig file to the project directory
+ */
+shelljs.cp([ TSLINT_PATH, EDITORCONFIG_PATH ], PROJECT_DIR);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "The style guide for typescript projects at Cinergix. ",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
-        "postinstall": "cp tslint.json ../../. && cp .editorconfig ../../."
+        "postinstall": "node .npm_scripts/postinstall"
     },
     "repository": {
         "type": "git",
@@ -18,5 +18,8 @@
     "bugs": {
         "url": "https://github.com/Cinergix/style-guide-typescript/issues"
     },
-    "homepage": "https://github.com/Cinergix/style-guide-typescript#readme"
+    "homepage": "https://github.com/Cinergix/style-guide-typescript#readme",
+    "dependencies": {
+        "shelljs": "^0.7.6"
+    }
 }


### PR DESCRIPTION
Enable support for windows by using shelljs to run scripts.
Also, only run postinstall steps if the module was a dependency.